### PR TITLE
Update Suivreuncolis.class.php

### DIFF
--- a/core/class/Suivreuncolis.class.php
+++ b/core/class/Suivreuncolis.class.php
@@ -641,7 +641,7 @@
 			
 		
 			$transnom = $this->getConfiguration('transporteur','');
-            $autcreation = $this->getConfiguration('autocreate','1');
+            		$autcreation = $this->getConfiguration('autocreate','1');
             
 			if ($transnom == "aftership" && $autcreation != '0'){
 				log::add('Suivreuncolis', 'debug', 'AutoCreation dans aftership' );
@@ -653,7 +653,7 @@
 					return;
 				}
 				
-				$nom = $this->getConfiguration('name','?');
+				$nom = $this->getName();
 				$numcolis = $this->getConfiguration('numsuivi',0);
 				$lecommentaire = $this->getConfiguration('commentaire','');
 				$transporteurAftership = $this->getConfiguration('transaftership','');
@@ -709,7 +709,7 @@
 				}
 				
 				
-				$nom = $this->getConfiguration('name','?');
+				$nom = $this->getName();
 				$numcolis = $this->getConfiguration('numsuivi',0);
 				$lecommentaire = $this->getConfiguration('commentaire','');
 				$transporteurAftership = $this->getConfiguration('transaftership','');


### PR DESCRIPTION
When automatically creating trackings from the Jeedom plug-in, with an automatic creation on AfterShip web site, the tracking name is always '?' on Aftership.

The problem comes from the line below, both in postSave() and post Remove() functions, that is not correct and needs to be replaced. With this new name are properly created on AfterShip from Jeedom

replace $nom = $this->getConfiguration('name','?');
by	$nom = $this->getName();